### PR TITLE
Fix compatibility issue with latest Jupyter Server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: test
 on:
   pull_request:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
 
 concurrency:
   group: test-${{ github.head_ref }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "s3contents"
+name = "jupyter-s3contents"
 description = "S3 Contents Manager for Jupyter"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -29,13 +29,14 @@ dependencies = [
   "nbconvert>=6.0,<8.0",
   "aiobotocore[boto3]>=1.4.0",
   "s3fs>=2021.11.0",
+  "jupyter-server"
 ]
 dynamic = ["version"]
 
 [project.urls]
-Documentation = "https://github.com/danielfrg/s3contents#readme"
-Issues = "https://github.com/danielfrg/s3contents/issues"
-Source = "https://github.com/danielfrg/s3contents"
+Documentation = "https://github.com/imfing/jupyter-s3contents#readme"
+Issues = "https://github.com/imfing/jupyter-s3contents/issues"
+Source = "https://github.com/imfing/jupyter-s3contents"
 
 [project.optional-dependencies]
 gcs = ["gcsfs>=2021.11.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ keywords = [
   "google cloud storage",
   "minio",
 ]
-authors = [{ name = "Daniel Rodriguez", email = "daniel@danielfrg.com" }]
+authors = [
+  { name = "Daniel Rodriguez", email = "daniel@danielfrg.com" },
+  { name = "Xin Fu", email = "xin@imfing.com" }
+]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",

--- a/s3contents/__about__.py
+++ b/s3contents/__about__.py
@@ -2,4 +2,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/s3contents/ipycompat.py
+++ b/s3contents/ipycompat.py
@@ -4,7 +4,6 @@ Utilities for managing compat between notebook versions.
 Taken from: https://github.com/quantopian/pgcontents/blob/master/pgcontents/utils/ipycompat.py
 """
 
-import notebook
 from ipython_genutils.importstring import import_item
 from ipython_genutils.py3compat import string_types
 from nbformat import from_dict, reads, writes
@@ -15,14 +14,14 @@ from nbformat.v4.nbbase import (
     new_raw_cell,
 )
 from nbformat.v4.rwbase import strip_transient
-from notebook.services.contents.checkpoints import (
+from jupyter_server.services.contents.checkpoints import (
     Checkpoints,
     GenericCheckpointsMixin,
 )
-from notebook.services.contents.filecheckpoints import GenericFileCheckpoints
-from notebook.services.contents.filemanager import FileContentsManager
-from notebook.services.contents.manager import ContentsManager
-from notebook.utils import to_os_path
+from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoints
+from jupyter_server.services.contents.filemanager import FileContentsManager
+from jupyter_server.services.contents.manager import ContentsManager
+from jupyter_server.utils import to_os_path
 from traitlets import (
     Any,
     Bool,
@@ -35,9 +34,6 @@ from traitlets import (
     validate,
 )
 from traitlets.config import Config
-
-if notebook.version_info[0] >= 7:  # noqa
-    raise ImportError("Jupyter Notebook versions 6 and up are not supported.")
 
 
 __all__ = [


### PR DESCRIPTION
There's an issue in the `s3contents`
```
Bad config encountered during initialization: The ‘contents_manager_class’ trait of a SingleUserLabApp instance expected a subclass of ‘jupyter_server.services.contents.manager.ContentsManager’, not the S3ContentsManager S3ContentsManager.
```

Use `jupyter_server.services.contents.manager.ContentsManager` as the base class since newer Jupyter extension manager enforces checking the class trait.